### PR TITLE
Add Common Knowledge attribution to footers

### DIFF
--- a/airsift/static/map/scaffolding.tsx
+++ b/airsift/static/map/scaffolding.tsx
@@ -8,6 +8,8 @@ export const Footer = () => {
       </a>
       <a href='https://citizensense.net/about/contact/'>Contact</a>
       <a className='ml-3' href='https://citizensense.net/about/terms/'>Terms &amp; Conditions</a>
+      <br />
+      <a href='https://commonknowledge.coop'>Site by Common Knowledge</a>
     </div>
   )
 }

--- a/airsift/templates/global/footer.html
+++ b/airsift/templates/global/footer.html
@@ -9,5 +9,7 @@
     </a>
     <a href='https://citizensense.net/about/contact/'>Contact</a>
     <a class='ml-3' href='https://citizensense.net/about/terms/'>Terms &amp; Conditions</a>
+    <br />
+    <a href='https://commonknowledge.coop'>Site by Common Knowledge</a>
   </div>
 </nav>


### PR DESCRIPTION
Adds a small linked "Site by Common Knowledge" label to the very bottom of the footer.

<img width="600" alt="Captura de Tela 2021-01-28 às 12 41 47" src="https://user-images.githubusercontent.com/237556/106140084-31809180-6166-11eb-8d6e-05385f0843c9.png">
