### PR TITLE
Display related observations

### DIFF
--- a/airsift/datastories/templates/datastories/data_story.html
+++ b/airsift/datastories/templates/datastories/data_story.html
@@ -31,16 +31,30 @@
             {{ page.date_from|date:"d.m.Y" }}-{{page.date_to|date:"d.m.Y" }}
           </div>
         </section>
+        {% if page.related_dustboxes.count > 0 %}
         <section class='my-4'>
           <header class='text-XXS font-bold uppercase font-cousine text-midDarker'>
-            Dustboxes
+            Related Dustboxes
           </header>
           <div class='text-XXS uppercase font-cousine text-midDarker mt-1'>
             {% for dustbox in page.related_dustboxes.all %}
-              <a href='/dustboxes/inspect/{{dustbox.id}}'>{{ dustbox.title }}</a>,
+              <a href='{{dustbox.url}}'>{{ dustbox.title }}</a>,
             {% endfor %}
           </div>
         </section>
+        {% endif %}
+        {% if page.related_observations.count > 0 %}
+        <section class='my-4'>
+          <header class='text-XXS font-bold uppercase font-cousine text-midDarker'>
+            Related Observations
+          </header>
+          <div class='text-XXS uppercase font-cousine text-midDarker mt-1'>
+            {% for observation in page.related_observations.all %}
+              <a href='{{observation.url}}'>{{ observation.title }}</a>,
+            {% endfor %}
+          </div>
+        </section>
+        {% endif %}
         <section class='my-4'>
           <header class='text-XXS font-bold uppercase font-cousine text-midDarker'>
             Contributors


### PR DESCRIPTION
This PR:

- Shows related observations if they exists
- Hides the related dustboxes caption if there aren't any to show

<img width="207" alt="Screenshot 2021-02-22 at 15 11 16" src="https://user-images.githubusercontent.com/237556/108727218-3b58a300-7520-11eb-97fa-2d7cb8aa2446.png">
